### PR TITLE
Switched owner/group on /var/log/php-fpm

### DIFF
--- a/SPECS/php70u.spec
+++ b/SPECS/php70u.spec
@@ -1729,7 +1729,7 @@ fi
 %endif
 %{_sbindir}/php-fpm
 %dir %{_sysconfdir}/php-fpm.d
-%attr(770,php-fpm,root) %dir %{_localstatedir}/log/php-fpm
+%attr(770,root,php-fpm) %dir %{_localstatedir}/log/php-fpm
 %{_mandir}/man8/php-fpm.8*
 %dir %{_datadir}/fpm
 %{_datadir}/fpm/status.html


### PR DESCRIPTION
All previous packages have had root:apache ownership, and as such we run FPM pools as someuser:apache in order to write logs here. 
I do agree that the php-fpm user is a good idea, to be apache/nginx agnostic, but  /var/log/php-fpm should be root:php-fpm and not php-fpm:root.

With 770 php-fpm:root, it's impossible to write logs here with running an FPM pool (correctly) as unpriviliged user. Our general practice is to have a different user per pool, and we don't want everything to run as php-fpm. 

Was this just an oversight or a conscious descision to completely lock down /var/log/php-fpm ?
